### PR TITLE
Handle secret hash for multiple issuers

### DIFF
--- a/lib/omniauth/jwt/version.rb
+++ b/lib/omniauth/jwt/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module JWT
-    VERSION = "1.1.1"
+    VERSION = "1.2.0"
   end
 end

--- a/lib/omniauth/strategies/jwt.rb
+++ b/lib/omniauth/strategies/jwt.rb
@@ -65,6 +65,8 @@ module OmniAuth
       def secret
         if options.secret.is_a?(String)
           options.secret
+        elsif options.secret.is_a?(Hash)
+          issuer_specific_secret
         else
           secret_lookup.secret
         end
@@ -76,6 +78,12 @@ module OmniAuth
 
       def uid_lookup
         @uid_lookup ||= options.uid_claim.new(request)
+      end
+
+      def issuer_specific_secret
+        unverified_token = ::JWT.decode(request.params['jwt'], nil, false)[0]
+        iss = unverified_token['iss']
+        options.secret[iss]
       end
     end
 

--- a/spec/lib/omniauth/strategies/jwt_spec.rb
+++ b/spec/lib/omniauth/strategies/jwt_spec.rb
@@ -92,5 +92,17 @@ describe OmniAuth::Strategies::JWT do
         expect(last_response.status).to eq(302)
       end
     end
+
+    describe 'secret' do
+      context 'multiple issuers' do
+        let(:args) { [{ issuer_1: 'secret_1', issuer_2: 'secret_2' }, {auth_url: 'http://example.com/login'}] }
+
+        it 'should assign the uid' do
+          encoded = JWT.encode({name: 'Steve', email: 'dude@awesome.com', iss: 'issuer_1'}, 'secret_1')
+          get '/auth/jwt/callback?jwt=' + encoded
+          expect(response_json["uid"]).to eq('dude@awesome.com')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows to send a hash of secrets which will vary depending on issuer.