### PR TITLE
Remove version lock from the jwt gem

### DIFF
--- a/lib/omniauth/jwt/version.rb
+++ b/lib/omniauth/jwt/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module JWT
-    VERSION = "1.2.0"
+    VERSION = "1.3.0"
   end
 end

--- a/omniauth-jwt.gemspec
+++ b/omniauth-jwt.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "rack-test"
 
-  spec.add_dependency "jwt", "~> 1.0"
+  spec.add_dependency "jwt"
   spec.add_dependency "omniauth", "~> 1.1"
 end


### PR DESCRIPTION
Remove the version lock, so that anything using this gem can update to jwt `v2.x` if needed.